### PR TITLE
Audit Remediation: Add CONTRIBUTING.md, LICENSE, and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to this project!
+
+## Code of Conduct
+
+All contributors are expected to follow our Code of Conduct. Please be respectful, inclusive, and constructive in all interactions.
+
+## How to Contribute
+
+### Reporting Issues
+
+Use the GitHub issue tracker to report bugs or request features. Please check existing issues first to avoid duplicates.
+
+### Submitting Pull Requests
+
+1. **Fork** the repository
+2. **Create a branch** from `main` with a descriptive name
+3. **Make your changes** following the style guide
+4. **Write tests** for any new functionality
+5. **Submit a PR** with a clear description of changes
+
+## Style Guide
+
+- Follow existing code style and conventions
+- Write clear, descriptive commit messages
+- Keep pull requests focused and atomic

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Acme Corp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+We provide security updates for the latest stable release.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not** open a public issue.
+
+Instead, please report it via email to: **security@company.com**
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes
+
+We will acknowledge your report within 48 hours and provide a timeline for a fix within 7 business days.
+
+## Responsible Disclosure
+
+We follow responsible disclosure principles. We ask that you:
+- Give us reasonable time to fix the issue before any public disclosure
+- Do not access or modify user data without permission
+- Act in good faith
+
+We will not take legal action against researchers who follow these guidelines.


### PR DESCRIPTION
## Audit Remediation: Add CONTRIBUTING.md, LICENSE, and SECURITY.md

This PR addresses the documentation gaps identified in the repository health audit.

### Changes

- **LICENSE**: Added MIT License (year 2026)
- **CONTRIBUTING.md**: Added contributor guidelines with workflow and style guide
- **SECURITY.md**: Added security policy with responsible disclosure process

### Related Issues

Fixes #38, Fixes #39, Fixes #40, Fixes #41, Fixes #42